### PR TITLE
refactor: implement result typing

### DIFF
--- a/cfspeedtest/__init__.py
+++ b/cfspeedtest/__init__.py
@@ -1,5 +1,10 @@
 """cfspeedtest, a Cloudflare speedtest suite in Python."""
 
-from cfspeedtest.cloudflare import CloudflareSpeedtest, TestSpec, TestType
+from cfspeedtest.cloudflare import (
+    CloudflareSpeedtest,
+    SuiteResults,
+    TestSpec,
+    TestType,
+)
 
-__all__ = ("CloudflareSpeedtest", "TestSpec", "TestType")
+__all__ = ("CloudflareSpeedtest", "SuiteResults", "TestSpec", "TestType")

--- a/cfspeedtest/__main__.py
+++ b/cfspeedtest/__main__.py
@@ -28,7 +28,7 @@ def cfspeedtest() -> None:
     )
     args = parser.parse_args()
 
-    setup_log(silent=args.json)
+    setup_log(silent=args.json and not args.version)
     set_verbosity(debug=args.debug)
 
     if args.version:
@@ -36,11 +36,11 @@ def cfspeedtest() -> None:
         log.debug("Python %s", sys.version)
         sys.exit(0)
 
-    results = CloudflareSpeedtest().run_all(megabits=not args.bps)
+    results = CloudflareSpeedtest().run_all()
 
     if args.json:
         setup_log()
-        log.info(json.dumps(CloudflareSpeedtest.results_to_dict(results)))
+        log.info(json.dumps(results.to_full_dict()))
 
 
 if __name__ == "__main__":

--- a/cfspeedtest/__main__.py
+++ b/cfspeedtest/__main__.py
@@ -4,7 +4,7 @@ import json
 import sys
 from argparse import ArgumentParser
 
-from cfspeedtest.cloudflare import CloudflareSpeedtest
+from cfspeedtest.cloudflare import CloudflareSpeedtest, SuiteResults
 from cfspeedtest.logger import log, set_verbosity, setup_log
 from cfspeedtest.version import __version__
 
@@ -36,7 +36,7 @@ def cfspeedtest() -> None:
         log.debug("Python %s", sys.version)
         sys.exit(0)
 
-    results = CloudflareSpeedtest().run_all()
+    results = CloudflareSpeedtest(SuiteResults(megabits=not args.bps)).run_all()
 
     if args.json:
         setup_log()

--- a/cfspeedtest/cloudflare.py
+++ b/cfspeedtest/cloudflare.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 import statistics
 import time
+from collections import UserDict
 from enum import Enum
 from typing import Any, NamedTuple
 
@@ -128,7 +129,52 @@ def _calculate_percentile(data: list[float], percentile: float) -> float:
     return edges[0] + (edges[1] - edges[0]) * rem
 
 
-SuiteResults = dict[str, dict[str, TestResult]]
+def bits_to_megabits(bits: int) -> float:
+    """Convert bits to megabits, rounded to 2 decimal places."""
+    return round(bits / 1e6, 2)
+
+
+class SuiteResults(UserDict):
+    """The results of a test suite."""
+
+    def __init__(self, *, megabits: bool = False):
+        super().__init__()
+        self.setdefault("tests", {})
+        self._megabits = megabits
+
+    @property
+    def meta(self) -> TestMetadata:
+        return self["meta"]
+
+    @meta.setter
+    def meta(self, value: TestMetadata) -> None:
+        self["meta"] = value
+        for meta_field, meta_value in value._asdict().items():
+            log.info("%s: %s", meta_field, meta_value)
+
+    @property
+    def tests(self) -> dict[str, TestResult]:
+        return self["tests"]
+
+    def add_test(self, label: str, result: TestResult):
+        self.tests[label] = result
+        log.info("%s: %s", label, result.value)
+
+    @property
+    def percentile_90th_down_bps(self) -> TestResult:
+        return self["90th_percentile_down_bps"]
+
+    @property
+    def percentile_90th_up_bps(self) -> TestResult:
+        return self["90th_percentile_up_bps"]
+
+    def to_full_dict(self) -> dict:
+        return {
+            "meta": self.meta._asdict(),
+            "tests": {k: v._asdict() for k, v in self.tests.items()},
+            "90th_percentile_down_bps": self.percentile_90th_down_bps,
+            "90th_percentile_up_bps": self.percentile_90th_up_bps,
+        }
 
 
 class CloudflareSpeedtest:
@@ -155,10 +201,7 @@ class CloudflareSpeedtest:
         no logging will occur.
 
         """
-        self.results = results or {}
-        self.results.setdefault("tests", {})
-        self.results.setdefault("meta", {})
-
+        self.results = results or SuiteResults()
         self.tests = tests
         self.request_sess = requests.Session()
         self.timeout = timeout
@@ -199,74 +242,42 @@ class CloudflareSpeedtest:
             )
         return coll
 
-    def _sprint(
-        self, label: str, result: TestResult, *, meta: bool = False
-    ) -> None:
-        """Add an entry to the suite results and log it."""
-        log.info("%s: %s", label, result.value)
-        save_to = self.results["meta"] if meta else self.results["tests"]
-        save_to[label] = result
+    def run_test_latency(self, test: TestSpec) -> None:
+        """Run a test specification and collect latency results."""
+        timers = self.run_test(test)
+        latencies = timers.to_latencies()
+        jitter = timers.jitter_from(latencies)
+        if jitter:
+            jitter = round(jitter, 2)
+        self.results.add_test(
+            "latency", TestResult(round(statistics.mean(latencies), 2))
+        )
+        self.results.add_test("jitter", TestResult(jitter))
 
-    def run_all(self, *, megabits: bool = False) -> SuiteResults:
+    def run_test_speed(self, test: TestSpec) -> list[int]:
+        """Run a test specification and collect speed results."""
+        speeds = self.run_test(test).to_speeds(test)
+        self.results.add_test(
+            f"{test.name}_{test.type.name.lower()}_bps",
+            TestResult(int(statistics.mean(speeds))),
+        )
+        return speeds
+
+    def run_all(self) -> SuiteResults:
         """Run the full test suite."""
-        meta = self.metadata()
-        self._sprint("ip", TestResult(meta.ip), meta=True)
-        self._sprint("isp", TestResult(meta.isp))
-        self._sprint("location_code", TestResult(meta.location_code), meta=True)
-        self._sprint("location_city", TestResult(meta.city), meta=True)
-        self._sprint("location_region", TestResult(meta.region), meta=True)
+        self.results.meta = self.metadata()
 
         data = {"down": [], "up": []}
         for test in self.tests:
-            timers = self.run_test(test)
-
             if test.name == "latency":
-                latencies = timers.to_latencies()
-                jitter = timers.jitter_from(latencies)
-                if jitter:
-                    jitter = round(jitter, 2)
-                self._sprint(
-                    "latency",
-                    TestResult(round(statistics.mean(latencies), 2)),
-                )
-                self._sprint("jitter", TestResult(jitter))
+                self.run_test_latency(test)
                 continue
-
-            speeds = timers.to_speeds(test)
-            data[test.type.name.lower()].extend(speeds)
-            # TODO: reduce code duplication of megabits reporting
-            mean_speed = int(statistics.mean(speeds))
-            label_suffix = "bps"
-            if megabits:
-                mean_speed = round(mean_speed / 1e6, 2)
-                label_suffix = "mbps"
-            self._sprint(
-                f"{test.name}_{test.type.name.lower()}_{label_suffix}",
-                TestResult(mean_speed),
-            )
+            data[test.type.name.lower()].extend(self.run_test_speed(test))
 
         for k, v in data.items():
             result = None
             if len(v) > 0:
                 result = int(_calculate_percentile(v, 0.9))
-            label_suffix = "bps"
-            if megabits:
-                result = round(result / 1e6, 2) if result else result
-                label_suffix = "mbps"
-            self._sprint(
-                f"90th_percentile_{k}_{label_suffix}",
-                TestResult(result),
-            )
+            self.results[f"90th_percentile_{k}_bps"] = TestResult(result)
 
         return self.results
-
-    @staticmethod
-    def results_to_dict(
-        results: SuiteResults,
-    ) -> dict[str, dict[str, dict[str, float]]]:
-        """Convert the test results to a full dictionary."""
-        return {
-            k: {sk: sv._asdict()}
-            for k, v in results.items()
-            for sk, sv in v.items()
-        }

--- a/cfspeedtest/cloudflare.py
+++ b/cfspeedtest/cloudflare.py
@@ -238,17 +238,17 @@ class CloudflareSpeedtest:
             )
         return coll
 
-    def run_test_latency(self, test: TestSpec) -> None:
+    def run_test_latency(self, test: TestSpec) -> tuple[float, float | None]:
         """Run a test specification and collect latency results."""
         timers = self.run_test(test)
         latencies = timers.to_latencies()
         jitter = timers.jitter_from(latencies)
         if jitter:
             jitter = round(jitter, 2)
-        self.results.add_test(
-            "latency", TestResult(round(statistics.mean(latencies), 2))
-        )
+        latency = round(statistics.mean(latencies), 2)
+        self.results.add_test("latency", TestResult(latency))
         self.results.add_test("jitter", TestResult(jitter))
+        return (latency, jitter)
 
     def run_test_speed(self, test: TestSpec) -> list[int]:
         """Run a test specification and collect speed results."""

--- a/cfspeedtest/cloudflare.py
+++ b/cfspeedtest/cloudflare.py
@@ -11,6 +11,7 @@ import statistics
 import time
 from collections import UserDict
 from enum import Enum
+from itertools import pairwise
 from typing import Any, NamedTuple
 
 import requests
@@ -98,12 +99,7 @@ class TestTimers(NamedTuple):
         """Compute jitter as average deviation between consecutive latencies."""
         if len(latencies) < 2:
             return None
-        return statistics.mean(
-            [
-                abs(latencies[i] - latencies[i - 1])
-                for i in range(1, len(latencies))
-            ]
-        )
+        return statistics.mean([abs(b - a) for a, b in pairwise(latencies)])
 
 
 class TestMetadata(NamedTuple):

--- a/cfspeedtest/cloudflare.py
+++ b/cfspeedtest/cloudflare.py
@@ -188,8 +188,8 @@ class SuiteResults(UserDict):
             "megabits": self._megabits,
             "meta": self.meta._asdict(),
             "tests": {k: v._asdict() for k, v in self.tests.items()},
-            "90th_percentile_down": self.percentile_90th_down,
-            "90th_percentile_up": self.percentile_90th_up,
+            "90th_percentile_down": self.percentile_90th_down._asdict(),
+            "90th_percentile_up": self.percentile_90th_up._asdict(),
         }
 
 

--- a/cfspeedtest/cloudflare.py
+++ b/cfspeedtest/cloudflare.py
@@ -40,6 +40,11 @@ class TestSpec(NamedTuple):
         """The size of the test in bits."""
         return self.size * 8
 
+    @property
+    def label(self) -> str:
+        """The output label for the test."""
+        return f"{self.name}_{self.type.name.lower()}"
+
 
 TestSpecs = tuple[TestSpec, ...]
 
@@ -270,7 +275,7 @@ class CloudflareSpeedtest:
         """Run a test specification and collect speed results."""
         speeds = self.run_test(test).to_speeds(test)
         self.results.add_test(
-            f"{test.name}_{test.type.name.lower()}",
+            test.label,
             TestResult(int(statistics.mean(speeds))),
         )
         return speeds


### PR DESCRIPTION
Fixes #23.

It came to my attention when I was working on martinbrose/cloudflare-speedtest-exporter#54 that it would be useful for end users to have a properly typed results class, instead of either having to work with a loosely structured dict or collect it into their own named tuples.

This also fixes a bug introduced in #19 where --json would omit some entries. See below:
![image](https://github.com/martinbrose/cloudflarepycli/assets/22531310/2948c4b4-e0c3-4aa4-a92e-5e7c3ce7e221)

I would recommend #21 be merged first, so this can serve as its successor, and possibly #22.

TODO:
- [x] Readd support for storing results in megabits.
  - Pick a strategy
    - Add `_mbps` keys alongside `_bps`
    - Convert keys to a tuple of `(bps, mbps)`
    - Store results as one or the other
- [ ] Decide whether this is worth a major version update so soon after the last one.
