### PR TITLE
Cloudflare speed test meta endpoint now requires a Referer header

### DIFF
--- a/cfspeedtest/cloudflare.py
+++ b/cfspeedtest/cloudflare.py
@@ -176,7 +176,8 @@ class CloudflareSpeedtest:
     def metadata(self) -> TestMetadata:
         """Retrieve test location code, IP address, ISP, city, and region."""
         result_data: dict[str, str] = self.request_sess.get(
-            "https://speed.cloudflare.com/meta"
+            "https://speed.cloudflare.com/meta",
+            headers={"Referer": "https://speed.cloudflare.com/"}
         ).json()
         return TestMetadata(
             result_data.get("clientIp"),


### PR DESCRIPTION
Previously the `https://speed.cloudflare.com/meta` endpoint used to return correct IP/ISP/location data, but now it appears that a `Referer` header is required.